### PR TITLE
テーマを hugo-blog-awesome v1.21.0 に更新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/csnagu/nagu.dev
 
 go 1.22.0
 
-require github.com/hugo-sid/hugo-blog-awesome v1.18.0 // indirect
+require github.com/hugo-sid/hugo-blog-awesome v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/hugo-sid/hugo-blog-awesome v1.18.0 h1:9+eWINeZCeQ/LL6P0cxRDAxvbfnsJlydkgCSNs+DGlY=
 github.com/hugo-sid/hugo-blog-awesome v1.18.0/go.mod h1:3XVERF66wgQpTsruOajS5Swr+uvyTzov1acafNaqm1E=
+github.com/hugo-sid/hugo-blog-awesome v1.21.0 h1:cxoeQgJePACmvPKqodDCLyme3iVAeGHm/l+iqyntGL4=
+github.com/hugo-sid/hugo-blog-awesome v1.21.0/go.mod h1:3XVERF66wgQpTsruOajS5Swr+uvyTzov1acafNaqm1E=

--- a/hugo.toml
+++ b/hugo.toml
@@ -96,6 +96,9 @@ avatar = "avatar.jpeg" # put the file in assets folder; also ensure that image h
 name = "csnagu"
 description = "Journal of engineering"
 
+[author]
+name = "csnagu"
+
 # Allow to override webmanifest options
 [params.webmanifest]
 name = "sitename"         # will use "params.sitename" or "title" by default

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,48 @@
+<!-- Based on the upstream rss template, but uses site params for author metadata. -->
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- $rssFeedDescription := .Site.Params.rssFeedDescription | default "summary" -}}
+{{- $authorName := .Site.Params.author.name -}}
+{{- $authorEmail := .Site.Params.author.email -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      {{ if eq $rssFeedDescription "summary" }}
+      <description>{{ .Summary | html }}</description>
+      {{ else if eq $rssFeedDescription "full" }}
+      <description>{{ .Content | html }}</description>
+      {{ else }} {{ errorf "Error in RSS feed generation %q" .Path }}
+      {{ end }}
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## 概要
- hugo-blog-awesome を v1.18.0 から v1.21.0 に更新
- 現在の Hugo で RSS テンプレートが落ちる問題を root override で吸収
- テーマ更新後もローカルで build / server 起動できる状態に調整

## 確認内容
- `hugo` build が正常完了
- `hugo server` が localhost で起動することを確認
- 既存の Mermaid / link card / ToC の override が引き続き動作することを確認
